### PR TITLE
Segundo trabalho de TecProg - Técnicas de Refatoração

### DIFF
--- a/irrf/test/test_deduction.py
+++ b/irrf/test/test_deduction.py
@@ -16,7 +16,8 @@ class TestDeduction(unittest.TestCase):
         ('Carne INSS 2', 200.0)
     ])
     def test_register_official_pension(self, description, value):
-        self.irrf.register_official_pension(description, value)
+        deduction_tuple = (description, value)
+        self.irrf.register_official_pension(deduction_tuple)
         self.assertEqual(self.irrf.get_total_official_pension(), value)
 
     @parameterized.expand([
@@ -82,7 +83,7 @@ class TestDeduction(unittest.TestCase):
     ])
     def test_other_deductions(self, objects, expect):
         for object in objects:
-            self.irrf.register_other_deductions(object[0], object[1])
+            self.irrf.register_other_deductions(object)
 
         self.assertEqual(self.irrf.get_other_deductions(), expect)
 

--- a/irrf/test/test_irrf.py
+++ b/irrf/test/test_irrf.py
@@ -245,7 +245,7 @@ class IRRFTestCase(unittest.TestCase):
         for deduction in deduction_list:
             self.irrf.register_deduction(deduction)
 
-        self.assertAlmostEqual(self.irrf.calculate_tax(), expected_tax, delta=0.01)
+        self.assertAlmostEqual(self.irrf.get_tax(), expected_tax, delta=0.01)
 
 
     @parameterized.expand([


### PR DESCRIPTION
# 1° Refatoração: Extrair método

**Maus-cheiros identificados**: 
* método longo;
* obsessão por tipos primitivos;
* aglomeração de dados.

**Descrição da refatoração**: a refatoração aplicada para dividir o método `register_deduction`, que apresentava um longo _if_ com aninhamento de comandos desnecessários, em métodos menores com responsabilidade única e com nomes significativos. Os métodos `register_official_pension` e `register_other_deductions` foram alterados para que a sua assinatura de parâmetros ficasse igual ao dos outros métodos de dedução. Também foram  criados métodos para percorrer as pensões alimentícias e os dependentes.

**Classes/métodos/atributos afetados:**

* Simplificação do if em um dicionário para a função register_deduction.
* Método register_deduction foi dividido nos métodos select_deduction_method e os métodos específicos para cada dedução.
* Mudança na assinatura da função register_official_pension para generalização do método.
* Criação do método loop_over_dependents para generalização do register_dependent.
* Adicionada uma camada intermediária ao método register_dependent para que este pudesse ter a mesma assinatura das outras deduções.
* Criação do método loop_over_food_pensions para generalização de register_food_pension.
* Adicionada uma camada intermediária ao método register_dependent para que este pudesse ter a mesma assinatura das outras deduções.
* Mudança na assinatura da função register_other_deductions para generalização do método.

# 2° Refatoração: Substituir método por método objeto

**Maus-cheiros identificados:** Aglomeração de dados

**Descrição da refatoração:** Aplicou-se a técnica substituir método por método objeto ao método calculate_tax, criando-se a classe CalculateTax e o método compute. Com isso, foi possível eliminar as variáveis temporárias da classe CalculateTax e dividir o método compute em novos métodos (extrair método).

**Classes/métodos/atributos afetados:**
* Método calculate_tax() da classe IRRF foi transformado na classe CalculateTax;
* Método compute() da classe CalculateTax (antigo calculate_tax() da classe IRRF) foi extraído em is_within_the_first_range(), is_within_the_second_range(), is_within_the_third_range(), calculate_tax_within_the_first_range(), calculate_tax_with_the_second_range(), calculate_tax_with_the_third_range(), calculate_tax_with_the_fourth_range() para facilitar o entendimento do código;
* Metódo calculate_tax() da classe IRRF foi renomeado para get_tax() e agora faz chamada ao método compute() da classe CalculateTax.

# 3° Refatoração: Extrair constant (Extract Variable)

**Maus-cheiros indetificados**:
* Comentários: Cada uma das constantes extraídas precisava de comentários para deixar claro o que significava aquele "valor mágico" (magic value).

**Descrição da refatoração**: A refatoração consistiu em substituir as constantes presente no código por ENUMS com nomes significativos, pois desta maneira o leitor do código poderá compreender o que tal constante significa mais intuitivamente.

**Classes/métodos/atributos afetados:**
* IRRF.calculate_tax